### PR TITLE
refactor: use centralized API service in conversation pages

### DIFF
--- a/frontend/src/pages/Conversation.js
+++ b/frontend/src/pages/Conversation.js
@@ -1,6 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
-import { getTurns, createTurn, getModelConfigs } from '../services/api';
+import {
+  getConversation,
+  getTurns,
+  createTurn,
+  getModelConfigs,
+  uploadDocument,
+} from '../services/api';
 
 function Conversation() {
   const { conversationId } = useParams();
@@ -24,7 +30,7 @@ function Conversation() {
 
   const fetchConversation = async () => {
     try {
-      const response = await axios.get(`${process.env.REACT_APP_API_URL}/conversations/${conversationId}`);
+      const response = await getConversation(conversationId);
       setConversation(response.data);
     } catch (err) {
       setError('Failed to fetch conversation details.');
@@ -72,15 +78,7 @@ function Conversation() {
 
     try {
       setUploading(true);
-      await axios.post(
-        `${process.env.REACT_APP_API_URL}/conversations/${conversationId}/documents`,
-        formData,
-        {
-          headers: {
-            'Content-Type': 'multipart/form-data',
-          },
-        }
-      );
+      await uploadDocument(conversationId, formData);
       // Reset file input
       if (fileInputRef.current) {
         fileInputRef.current.value = '';

--- a/frontend/src/pages/ConversationList.js
+++ b/frontend/src/pages/ConversationList.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import axios from 'axios';
+import { getConversations, createConversation } from '../services/api';
 
 function ConversationList() {
   const [conversations, setConversations] = useState([]);
@@ -15,7 +15,7 @@ function ConversationList() {
   const fetchConversations = async () => {
     try {
       setLoading(true);
-      const response = await axios.get(`${process.env.REACT_APP_API_URL}/conversations`);
+      const response = await getConversations();
       setConversations(response.data);
       setError(null);
     } catch (err) {
@@ -31,8 +31,8 @@ function ConversationList() {
     if (!newConversationName.trim()) return;
 
     try {
-      const response = await axios.post(`${process.env.REACT_APP_API_URL}/conversations`, {
-        name: newConversationName
+      const response = await createConversation({
+        name: newConversationName,
       });
       setConversations([...conversations, response.data]);
       setNewConversationName('');

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -10,6 +10,15 @@ const api = axios.create({
   },
 });
 
+// Global error handling for all requests
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    console.error('API error:', error);
+    return Promise.reject(error);
+  }
+);
+
 // Conversations
 export const getConversations = () => api.get('/conversations');
 export const getConversation = (id) => api.get(`/conversations/${id}`);


### PR DESCRIPTION
## Summary
- replace direct axios calls in ConversationList and Conversation components with shared API service functions
- add global axios interceptor for consistent error handling

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689e1d0e4cac832eba996f07308ed63a