### PR TITLE
Use deterministic embedding fallback when OpenAI key missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ roundtable/
    export ANTHROPIC_API_KEY=your_anthropic_api_key
    export DEEPSEEK_API_KEY=your_deepseek_api_key
    ```
+   If `OPENAI_API_KEY` is omitted, the backend uses a deterministic hash-based
+   embedding for development and testing. These vectors are reproducible but do
+   **not** capture semantic meaning, so a real API key is required for
+   production usage.
 
 ### Running the Application
 

--- a/app/services/embedding_service.py
+++ b/app/services/embedding_service.py
@@ -1,3 +1,4 @@
+import hashlib
 import openai
 import os
 import numpy as np
@@ -10,11 +11,28 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 EMBEDDING_MODEL = "text-embedding-ada-002"
 EMBEDDING_DIMENSION = 1536  # Dimension of OpenAI's text-embedding-ada-002
 
+def _deterministic_embedding(text: str) -> List[float]:
+    """Generate a deterministic embedding using a hash of the text.
+
+    This is used in development when ``OPENAI_API_KEY`` is not set. The
+    resulting vector is repeatable for the same input but carries no semantic
+    meaning.
+    """
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    seed = int.from_bytes(digest[:8], "little")
+    rng = np.random.default_rng(seed)
+    return rng.uniform(-1, 1, EMBEDDING_DIMENSION).tolist()
+
+
 async def generate_embedding(text: str) -> List[float]:
-    """Generate embedding for text using OpenAI API"""
+    """Generate embedding for text using OpenAI API.
+
+    Falls back to a deterministic hash-based vector when ``OPENAI_API_KEY``
+    is not provided. This fallback is intended only for local development
+    and testing.
+    """
     if not OPENAI_API_KEY:
-        # For development without API key, generate random embeddings
-        return list(np.random.uniform(-1, 1, EMBEDDING_DIMENSION))
+        return _deterministic_embedding(text)
     
     # Set OpenAI API key
     openai.api_key = OPENAI_API_KEY
@@ -31,10 +49,13 @@ async def generate_embedding(text: str) -> List[float]:
     return embedding
 
 def generate_embedding_sync(text: str) -> List[float]:
-    """Synchronous version of generate_embedding for internal use"""
+    """Synchronous version of ``generate_embedding`` for internal use.
+
+    Mirrors the asynchronous function's behavior, including the deterministic
+    fallback when ``OPENAI_API_KEY`` is unset.
+    """
     if not OPENAI_API_KEY:
-        # For development without API key, generate random embeddings
-        return list(np.random.uniform(-1, 1, EMBEDDING_DIMENSION))
+        return _deterministic_embedding(text)
     
     # Set OpenAI API key
     openai.api_key = OPENAI_API_KEY


### PR DESCRIPTION
## Summary
- replace random embedding generation with deterministic hash-based fallback when `OPENAI_API_KEY` is not set
- document how embedding generation behaves without an OpenAI key

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e1d3306c8832ea160e8158facb4f2