### PR TITLE
Add endpoint tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,9 @@ python-multipart==0.0.6
 openai==0.27.6
 nltk==3.8.1
 numpy==1.24.3
-pydantic==1.10.7
+pydantic==1.10.22
 python-dotenv==1.0.0
 pgvector>=0.2.0
 spacy==3.5.3
+httpx==0.24.1
+pytest==7.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,68 @@
+import sys
+import types
+import pathlib
+import os
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# Ensure project root is on sys.path
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+# Use SQLite for tests to avoid requiring PostgreSQL driver
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+
+import app  # noqa: F401
+
+# Stub heavy services before importing the FastAPI app
+stub_document_processor = types.ModuleType("document_processor")
+
+async def process_document(document_id: int, db):
+    return 0
+
+stub_document_processor.process_document = process_document
+sys.modules["app.services.document_processor"] = stub_document_processor
+
+stub_agent_service = types.ModuleType("agent_service")
+
+async def generate_turn_response(conversation_id: int, turn_number: int, query=None, db=None, model_config_id=None):
+    return "test response", "test thoughts"
+
+stub_agent_service.generate_turn_response = generate_turn_response
+sys.modules["app.services.agent_service"] = stub_agent_service
+
+from app.db import get_db
+from app.models.base import Base
+from app.main import app
+
+# Set up test database (SQLite in-memory)
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Create tables
+Base.metadata.create_all(bind=engine)
+
+# Dependency override
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+
+import pytest
+
+@pytest.fixture()
+def client():
+    with TestClient(app) as c:
+        yield c

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,73 @@
+from fastapi.testclient import TestClient
+
+
+def test_conversation_document_turn_crud(client: TestClient):
+    # Create conversation
+    resp = client.post("/api/conversations", json={"name": "Test Conversation"})
+    assert resp.status_code == 201
+    conv = resp.json()
+    conv_id = conv["id"]
+
+    # List conversations
+    resp = client.get("/api/conversations")
+    assert resp.status_code == 200
+    assert any(c["id"] == conv_id for c in resp.json())
+
+    # Get conversation
+    resp = client.get(f"/api/conversations/{conv_id}")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Test Conversation"
+
+    # Upload document
+    files = {"file": ("test.txt", b"Hello world")}
+    resp = client.post(f"/api/conversations/{conv_id}/documents", files=files)
+    assert resp.status_code == 201
+    doc = resp.json()
+    doc_id = doc["id"]
+    assert doc["filename"] == "test.txt"
+
+    # List documents
+    resp = client.get(f"/api/conversations/{conv_id}/documents")
+    assert resp.status_code == 200
+    docs = resp.json()
+    assert len(docs) == 1 and docs[0]["id"] == doc_id
+
+    # Get document
+    resp = client.get(f"/api/documents/{doc_id}")
+    assert resp.status_code == 200
+    assert resp.json()["filename"] == "test.txt"
+
+    # Delete document
+    resp = client.delete(f"/api/documents/{doc_id}")
+    assert resp.status_code == 204
+
+    # Ensure document deleted
+    resp = client.get(f"/api/conversations/{conv_id}/documents")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+    # Create turn
+    resp = client.post(f"/api/conversations/{conv_id}/turns", json={"query": "Hello"})
+    assert resp.status_code == 201
+    turn = resp.json()
+    turn_id = turn["id"]
+    assert turn["turn_number"] == 1
+
+    # List turns
+    resp = client.get(f"/api/conversations/{conv_id}/turns")
+    assert resp.status_code == 200
+    turns = resp.json()
+    assert len(turns) == 1 and turns[0]["id"] == turn_id
+
+    # Get turn
+    resp = client.get(f"/api/turns/{turn_id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == turn_id
+
+    # Delete conversation
+    resp = client.delete(f"/api/conversations/{conv_id}")
+    assert resp.status_code == 204
+
+    # Ensure conversation deleted
+    resp = client.get(f"/api/conversations/{conv_id}")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add pytest-based tests covering conversation, document and turn endpoints
- stub heavy services and use in-memory SQLite for isolation
- run tests in GitHub Actions and add testing dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e1cf8f850832e934391ea150f1677