### PR TITLE
Allow persona reuse in conversation order

### DIFF
--- a/alembic/versions/ea956b3e4186_add_persona_order_and_voting_models.py
+++ b/alembic/versions/ea956b3e4186_add_persona_order_and_voting_models.py
@@ -27,7 +27,6 @@ def upgrade() -> None:
     sa.ForeignKeyConstraint(['conversation_id'], ['conversations.id'], ),
     sa.ForeignKeyConstraint(['model_config_id'], ['model_configs.id'], ),
     sa.PrimaryKeyConstraint('id'),
-    sa.UniqueConstraint('conversation_id', 'model_config_id', name='uix_persona_order_conversation_model'),
     sa.UniqueConstraint('conversation_id', 'order_position', name='uix_persona_order_conversation_position')
     )
     op.create_index(op.f('ix_persona_orders_id'), 'persona_orders', ['id'], unique=False)

--- a/app/api/persona_orders.py
+++ b/app/api/persona_orders.py
@@ -50,18 +50,6 @@ def create_persona_order(
     if not model_config:
         raise HTTPException(status_code=404, detail="Model configuration not found")
     
-    # Check if this persona is already in the order
-    existing_order = db.query(PersonaOrder).filter(
-        PersonaOrder.conversation_id == conversation_id,
-        PersonaOrder.model_config_id == persona_order.model_config_id
-    ).first()
-    
-    if existing_order:
-        raise HTTPException(
-            status_code=400, 
-            detail="This persona is already in the conversation order"
-        )
-    
     # Check if the position is already taken
     position_taken = db.query(PersonaOrder).filter(
         PersonaOrder.conversation_id == conversation_id,
@@ -104,10 +92,10 @@ def list_persona_orders(conversation_id: int, db: Session = Depends(get_db)):
     return persona_orders
 
 
-@router.put("/conversations/{conversation_id}/persona-orders/{model_config_id}", response_model=PersonaOrderResponse)
+@router.put("/conversations/{conversation_id}/persona-orders/{order_id}", response_model=PersonaOrderResponse)
 def update_persona_order(
     conversation_id: int,
-    model_config_id: int,
+    order_id: int,
     persona_order: PersonaOrderUpdate,
     db: Session = Depends(get_db)
 ):
@@ -120,7 +108,7 @@ def update_persona_order(
     # Check if the persona order exists
     db_persona_order = db.query(PersonaOrder).filter(
         PersonaOrder.conversation_id == conversation_id,
-        PersonaOrder.model_config_id == model_config_id
+        PersonaOrder.id == order_id
     ).first()
     
     if not db_persona_order:
@@ -130,7 +118,7 @@ def update_persona_order(
     position_taken = db.query(PersonaOrder).filter(
         PersonaOrder.conversation_id == conversation_id,
         PersonaOrder.order_position == persona_order.order_position,
-        PersonaOrder.model_config_id != model_config_id
+        PersonaOrder.id != order_id
     ).first()
     
     if position_taken:
@@ -147,8 +135,8 @@ def update_persona_order(
     return db_persona_order
 
 
-@router.delete("/conversations/{conversation_id}/persona-orders/{model_config_id}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_persona_order(conversation_id: int, model_config_id: int, db: Session = Depends(get_db)):
+@router.delete("/conversations/{conversation_id}/persona-orders/{order_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_persona_order(conversation_id: int, order_id: int, db: Session = Depends(get_db)):
     """Remove a persona from the conversation order"""
     # Check if conversation exists
     conversation = db.query(Conversation).filter(Conversation.id == conversation_id).first()
@@ -158,7 +146,7 @@ def delete_persona_order(conversation_id: int, model_config_id: int, db: Session
     # Check if the persona order exists
     db_persona_order = db.query(PersonaOrder).filter(
         PersonaOrder.conversation_id == conversation_id,
-        PersonaOrder.model_config_id == model_config_id
+        PersonaOrder.id == order_id
     ).first()
     
     if not db_persona_order:

--- a/app/models/persona_order.py
+++ b/app/models/persona_order.py
@@ -17,10 +17,12 @@ class PersonaOrder(Base, TimestampMixin):
     conversation = relationship("Conversation", back_populates="persona_orders")
     model_config = relationship("ModelConfig", back_populates="persona_orders")
     
-    # Ensure each persona appears only once in the order for a conversation
+    # Only enforce unique positions within a conversation so the same persona
+    # can appear multiple times in the order (allowing an agent to "talk to
+    # itself" or be configured in multiple slots).
     __table_args__ = (
-        UniqueConstraint('conversation_id', 'model_config_id', name='uix_persona_order_conversation_model'),
-        UniqueConstraint('conversation_id', 'order_position', name='uix_persona_order_conversation_position'),
+        UniqueConstraint('conversation_id', 'order_position',
+                         name='uix_persona_order_conversation_position'),
     )
     
     def __repr__(self):


### PR DESCRIPTION
## Summary
- permit the same persona to appear multiple times in a conversation's order
- rotate personas by turn number so agents can "talk to themselves"
- update persona-order APIs to use order IDs and allow duplicates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e1be927a4832ea2c04e2fa45fdefc