### PR TITLE
Add validation for document uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ roundtable/
 
 ### Documents
 
+- Accepted file types: plain text files (`.txt`, `.md`) and text-based PDFs (`.pdf`) up to 1 MB
 - `POST /api/conversations/{conversation_id}/documents`: Upload a document
 - `GET /api/conversations/{conversation_id}/documents`: List all documents in a conversation
 - `GET /api/documents/{document_id}`: Get a specific document

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pydantic==1.10.7
 python-dotenv==1.0.0
 pgvector>=0.2.0
 spacy==3.5.3
+PyPDF2==3.0.1


### PR DESCRIPTION
## Summary
- validate document uploads for allowed file types and size, including text-based PDFs
- handle UTF-8 and PDF processing errors with clear 400 responses
- note supported document types in README and include PyPDF2 dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e1d5846c0832e8c8021c196ce589a